### PR TITLE
Add base schema and example Airtable data

### DIFF
--- a/airtable/base-schema.json
+++ b/airtable/base-schema.json
@@ -1,1 +1,60 @@
-
+{
+  "tables": [
+    {
+      "name": "saves",
+      "fields": [
+        {"name": "url", "type": "url"},
+        {"name": "title", "type": "singleLineText"},
+        {"name": "source", "type": "singleLineText"},
+        {"name": "status", "type": "singleSelect", "options": ["Inbox", "Tagged", "Archived"]}
+      ]
+    },
+    {
+      "name": "tasks",
+      "fields": [
+        {"name": "name", "type": "singleLineText"},
+        {"name": "project", "type": "linkToAnotherRecord", "linkedTable": "projects"},
+        {"name": "status", "type": "singleSelect", "options": ["To-Do", "Doing", "Done"]},
+        {"name": "due_date", "type": "date"}
+      ]
+    },
+    {
+      "name": "projects",
+      "fields": [
+        {"name": "name", "type": "singleLineText"},
+        {"name": "description", "type": "longText"},
+        {"name": "owner", "type": "singleLineText"}
+      ]
+    },
+    {
+      "name": "notes",
+      "fields": [
+        {"name": "title", "type": "singleLineText"},
+        {"name": "content", "type": "longText"},
+        {"name": "linked_record", "type": "singleLineText"}
+      ]
+    },
+    {
+      "name": "prompts",
+      "fields": [
+        {"name": "name", "type": "singleLineText"},
+        {"name": "content", "type": "longText"}
+      ]
+    },
+    {
+      "name": "sops",
+      "fields": [
+        {"name": "title", "type": "singleLineText"},
+        {"name": "steps", "type": "longText"}
+      ]
+    },
+    {
+      "name": "focus_logs",
+      "fields": [
+        {"name": "task", "type": "linkToAnotherRecord", "linkedTable": "tasks"},
+        {"name": "start", "type": "dateTime"},
+        {"name": "end", "type": "dateTime"}
+      ]
+    }
+  ]
+}

--- a/airtable/example-data.csv
+++ b/airtable/example-data.csv
@@ -1,0 +1,9 @@
+table,url,title,source,status,name,project,due_date,description,owner,content,linked_record,steps,task,start,end
+saves,https://example.com/article,Interesting Article,Google Feed,Inbox,,,,,,,,,,,
+saves,https://youtube.com/watch?v=12345,AI Video,YouTube,Tagged,,,,,,,,,,,
+tasks,,,,To-Do,Draft launch email,Alpha Project,2025-08-15,,,,,,,,
+projects,,,,,Alpha Project,,Launch of new site,Alice,,,,,,,
+notes,,Meeting Notes,,,,,,,,Meeting notes from kickoff,Alpha Project,,,,
+prompts,,,,,Daily Summary,,,,,Summarize new ideas,,,,,
+sops,,Release Checklist,,,,,,,,1. Build -> Test -> Deploy,,,,,
+focus_logs,,,,,,,,,,,,Draft launch email,2025-08-01T09:00:00Z,2025-08-01T10:00:00Z,

--- a/airtable/interface-configs/README.md
+++ b/airtable/interface-configs/README.md
@@ -1,0 +1,3 @@
+# Interface Configurations
+
+This directory stores JSON exports from Airtable's Interface Designer. Each file will represent the layout and settings for a specific dashboard view.


### PR DESCRIPTION
## Summary
- define Airtable tables and fields
- provide sample records for reference
- document how interface configuration files will be stored

## Testing
- `true`


------
https://chatgpt.com/codex/tasks/task_e_68865c9c066083319d079a947363949e