### PR TITLE
Add root .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,31 @@
+# OS-generated files
+.DS_Store
+Thumbs.db
+ehthumbs.db
+Icon?
+desktop.ini
+
+# Node and n8n dependencies
+node_modules/
+**/node_modules/
+
+# Build and compiled output
+/dist/
+/build/
+*.pyc
+__pycache__/
+*.class
+*.o
+*.out
+*.exe
+*.dll
+*.so
+*.a
+
+# Personal data exports
+exports/
+**/exports/
+personal-data/
+*.zip
+*.tar
+*.tar.gz


### PR DESCRIPTION
## Summary
- add repo-wide `.gitignore` to filter OS cruft, node modules, build artifacts and personal export files

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68866a9b1b0083318620e76db6ef95df